### PR TITLE
adding gfortran to ubuntu requirements

### DIFF
--- a/ubuntu/apt-packages
+++ b/ubuntu/apt-packages
@@ -1,6 +1,7 @@
 build-essential
 curl
 emacs
+gfortran
 htop
 libblas-dev
 libbz2-dev


### PR DESCRIPTION
Without gfortran, `make lisp` fails.