### PR TITLE
Adding pyenv to the path after installation.

### DIFF
--- a/python/pyenv.sh
+++ b/python/pyenv.sh
@@ -14,6 +14,7 @@ if [ ! -d "$HOME/.pyenv" ]
 then
     echo "Pyenv does not exist, installing now... (this takes about 10 minutes)"
     curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
+    PATH="$HOME/.pyenv/bin:$PATH"
     echo "Installing Python 3.6.3..."
     pyenv install 3.6.3
     echo "Installing Python 2.7.14..."


### PR DESCRIPTION
`make python` stops early on Ubuntu 17.10 unless the path is updated after installation. 

Note that this does not edit the `.bashrc` file as recommended by pyenv with:
```
export PATH="$HOME/.pyenv/bin:$PATH"
eval "$(pyenv init -)"
eval "$(pyenv virtualenv-init -)"
```
